### PR TITLE
Install cargo before publish workflow

### DIFF
--- a/.github/workflows/workers_deploy.yml
+++ b/.github/workflows/workers_deploy.yml
@@ -11,6 +11,9 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Publish
         uses: cloudflare/wrangler-action@2.0.0
         with:


### PR DESCRIPTION
# Description
Publish workflow fails because cargo is not installed. This PR adds a step to install cargo (using the actions-rs github action) before publishing.

## Type of change
- [X] Bug fix
- [ ] Improvement
- [ ] New Feature

#### Documentation
- [ ] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
