### PR TITLE
Upgrade wrangler to version 2

### DIFF
--- a/.github/workflows/workers_deploy.yml
+++ b/.github/workflows/workers_deploy.yml
@@ -11,11 +11,14 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - run: |
-          cargo install wrangler
+          npm install wrangler
           mkdir -p ~/.wrangler/config/
           echo "api_token=\"${CF_API_TOKEN}\"" > ~/.wrangler/config/default.toml
           wrangler publish


### PR DESCRIPTION
# Description
The wrangler crate uses the latest version of wrangler 1, but we want to build using wrangler 2, which is only available via npm.

## Type of change
- [X] Bug fix
- [ ] Improvement
- [ ] New Feature

#### Documentation
- [ ] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
