### PR TITLE
Replace npm install with npx run

### DIFF
--- a/.github/workflows/workers_deploy.yml
+++ b/.github/workflows/workers_deploy.yml
@@ -18,10 +18,9 @@ jobs:
         with:
           toolchain: stable
       - run: |
-          npm install wrangler
           mkdir -p ~/.wrangler/config/
           echo "api_token=\"${CF_API_TOKEN}\"" > ~/.wrangler/config/default.toml
-          wrangler publish
+          npx wrangler publish
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
# Description
Instead of installing wrangler using `npm` and having to deal with versions, we can use `npx` to just run it once.

## Type of change
- [ ] Bug fix
- [X] Improvement
- [ ] New Feature

#### Documentation
- [ ] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
