### PR TITLE
Add option to skip uploading binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You will need to enable Powershell scripts in the Windows security settings to r
 
 By default, the script uploads everything from `./static/`. If you wish to change this behavior, you can use the `-base` flag. The default namespace is `STATIC`. You can change this by using the `-binding` flag.
 
+### Binary Files
+
 For binary files, the script uses the `wrangler kv:bulk` utility to upload base64 encoded versions to Workers KV, which automatically decodes them before storing the raw bytes. This ensures that the Worker can serve binary file formats without any special accomodation. Currently, the upload script only supports the following binary file formats:
 - jpg
 - jpeg
@@ -72,3 +74,7 @@ For binary files, the script uses the `wrangler kv:bulk` utility to upload base6
 This is the same list of binary file encodings supported by the Worker. If you wish to add more binary content types, add them to the array `$BinaryExtensions` in [kv-bulk-uplad.ps1](kv-bulk-upload.ps1). Make sure to associate the approriate `Content-Type` header in [libs.rs](src/libs.rs) so that the Worker can serve the new file type (and submit a pull request upstream to add them for everyone!).
 
 The default filename for bulk uploads is the file `kv-bulk.json`, which is included in the .gitignore for that reason. If you wish to change the default, you can do so with the `-outfile` flag. Keep in mind that the result of base64 encoding many large binary files can be very large, so you may want to delete the outfile after uploading.
+
+#### Skipping Binary Files
+
+If you wish to skip uploading binary files (e.g. because they take too long), use the `-skipbinary` flag.


### PR DESCRIPTION
# Description
Binary files can be large and take a long time (and a lot of space) to reupload every time. This PR adds a switch to `kv-bulk-upload.ps1` to skip binary files and only upload text files.

## Type of change
- [ ] Bug fix
- [X] Improvement
- [ ] New Feature

#### Documentation
- [x] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
