### PR TITLE
Fix typo

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -40,7 +40,7 @@
         <p>If you're looking to hire a new-grad software engineer, quantitative developer, or machine learning engineer, check out my <a href="/resume">resume</a> (or the printable version <a href="/resume.pdf">here</a>).</p>
         <hr style="height: 1px">
         <h2>about this website</h2>
-        <p>This serverless website was written in Rust (compiled to WebAssembly) by me and runs on Cloudflare Workers. It serves static webpage stored in Workers KV. All styling is done with static assets and pure Javascript for minimal load times and smaller download sizes.</p>
+        <p>This serverless website was written in Rust (compiled to WebAssembly) by me and runs on Cloudflare Workers. It serves static webpages stored in Workers KV. All styling is done with static assets and pure Javascript for minimal load times and smaller download sizes.</p>
         <p>Check out the source code on <a href="https://github.com/0x65-e/mattcraig.tech">Github</a>!</p>
     </div>
 </body>

--- a/static/resume.html
+++ b/static/resume.html
@@ -85,7 +85,10 @@
 			<p>- GPA 3.975/4.0</p>
 			<p>- Dean's Honors List</p>
 			<p>- Member of Upsilon Pi Epsilon, Tau Beta Pi, and Mortar Board honor societies</p>
-			<h3><a href="/transcript" class="hover-link">RELEVANT COURSEWORK</a></h3>
+			<div class="link-container">
+				<a href="/transcript" class="hover-link"><h3>RELEVANT COURSEWORK</h3></a>
+				<i class="fas fa-link"></i>
+			</div>
 			<h5><a href="/transcript#CS" class="hover-link">Computer Science</a></h5>
 			<p>
 				Data Structures<br/>


### PR DESCRIPTION
# Description
Fixes a typo on index.html and adds a link icon to the transcript link on the resume page that was supposed to be added in #27 .

## Type of change
- [X] Bug fix
- [ ] Improvement
- [ ] New Feature

#### Documentation
- [ ] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
