### PR TITLE
Autodetect existing kv to make workflow reruns easier

### DIFF
--- a/.github/scripts/setup_test_worker.sh
+++ b/.github/scripts/setup_test_worker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Append a pr number to the worker name
+sed -i "s/\"mattcraig-tech\"/\"mattcraig-tech-pr${PR_NUMBER}\"/" wrangler.toml
+# Test for an existing kv in this worker's namespace bound to STATIC and create one if not present
+npx wrangler kv:namespace list > namespaces.txt
+if grep -q mattcraig-tech-pr${PR_NUMBER}-STATIC namespaces.txt; then
+	NAMESPACE="{ binding = \"STATIC\", id = $(cat namespaces.txt | sed ":again;\$!N;\$!b again; s/.*\({[^}]*mattcraig-tech-pr${PR_NUMBER}-STATIC[^}]*}\).*/\1/" | sed ':again;$!N;$!b again; s/.*\"id\": \([^,]*\).*/\1/') }"
+else
+	NAMESPACE=$(npx wrangler kv:namespace create STATIC | sed ':again;$!N;$!b again; s/.*\({[^}]*}\).*/\1/g')
+fi
+echo $NAMESPACE
+sed -i "s/{[^}]*}/${NAMESPACE}/g" wrangler.toml
+cat wrangler.toml

--- a/.github/workflows/workers_testing.yml
+++ b/.github/workflows/workers_testing.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Checkout, Build, and Publish
+    name: Checkout, Build, and Publish Test Worker
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -22,12 +22,7 @@ jobs:
           toolchain: stable
       - name: Create a testing KV and modify wrangler.toml
         shell: bash
-        run: |
-          sed -i "s/mattcraig-tech/mattcraig-tech-pr${PR_NUMBER}/" wrangler.toml
-          NAMESPACE=$(npx wrangler kv:namespace create STATIC | sed ':again;$!N;$!b again; s/.*\({[^}]*}\).*/\1/g')
-          echo $NAMESPACE
-          sed -i "s/{[^}]*}/${NAMESPACE}/g" wrangler.toml
-          cat wrangler.toml
+        run: . ./.github/scripts/setup_test_worker.sh
         env:
           PR_NUMBER: ${{ github.event.number }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
# Description
Rerunning a PR workflow requires manually deleting the KV for the test worker, which is cumbersome. This PR adds a setup script that automatically detects an existing KV for a test worker and uses it, or creates a new one if not present.

## Type of change
- [X] Bug fix
- [ ] Improvement
- [ ] New Feature

#### Documentation
- [ ] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
