### PR TITLE
Speed up CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# About
+# mattcraig.tech: Serverless Website in Rust!
+
+[![Build Status](https://img.shields.io/github/actions/workflow/status/0x65-e/mattcraig.tech/workers_deploy.yml?branch=master&logo=github&style=flat-square)](https://github.com/0x65-e/mattcraig.tech/actions/workflows/workers_deploy.yml)
+
+## About
 
 This website is written for Cloudflare Workers using Rust and the [workers-rs](https://github.com/cloudflare/workers-rs) crate. Cloudflare workers is a serverless, "function as a service" (FaaS) platform that runs across distributed data centers.
 
 It serves static files stored in Workers KV, a serverless key-value store on the edge.
+
+### links.mattcraig.tech
+
+The subdomain [links.mattcraig.tech](https://links.mattcraig.tech) hosts [another Worker](https://github.com/0x65-e/links.mattcraig.tech) that serves as a link shortener. 
 
 ## Usage
 
@@ -29,15 +37,15 @@ wrangler kv:namespace create "STATIC" --preview
 wrangler kv:namespace create "STATIC"
 ```
 
-You can choose a name other than `STATIC` for your namespace, but be sure to update the KV access in [libs.rs](src/lib.rs).
+If you choose a name other than `STATIC` for your namespace, be sure to update the KV access in [libs.rs](src/lib.rs) and the namespace binding in [wrangler.toml](wrangler.toml).
 
 You may also want to change the name of your worker in [wrangler.toml](wrangler.toml).
 
 ## Static Files
 
-Static files are stored in the `./static/` directory. To serve static assets, they must first be uploaded to Workers KV. This is possible to do in bulk using the included Powershell script [kv-bulk-upload.ps1](kv-bulk-upload.ps1). This keys each file with its relative path from the static directory (or whichever base directory you specify), which makes it easy to see your website layout on the filesystem. For example, the file `static/index.html` is mapped to the key `index.html` in the KV, while `static/assets/css/resume.css` becomes `assets/css/resume.css`.
+Static files are stored in the `static/` directory. To serve static assets, they must first be uploaded to Workers KV. This is possible to do in bulk using the included Powershell script [kv-bulk-upload.ps1](kv-bulk-upload.ps1). This keys each file with its relative path from the static directory (or whichever base directory you specify), which makes it easy to see your website layout on the filesystem. For example, the file `static/index.html` is mapped to the key `index.html` in the KV, while `static/assets/css/resume.css` becomes `assets/css/resume.css`.
 
-You will need to enable Powershell scripts in the Windows security settings to run the upload script.
+You will need to enable Powershell scripts in the Windows security settings to run the upload script. This script requires [Powershell 6.0 or later](https://aka.ms/pscore6), which is **not** installed by default in Windows 10 and Windows 11.
 
 ```powershell
 # uploads all contents of ./static/ directory to preview namespace
@@ -52,23 +60,12 @@ By default, the script uploads everything from `./static/`. If you wish to chang
 ### Binary Files
 
 For binary files, the script uses the `wrangler kv:bulk` utility to upload base64 encoded versions to Workers KV, which automatically decodes them before storing the raw bytes. This ensures that the Worker can serve binary file formats without any special accomodation. Currently, the upload script only supports the following binary file formats:
-- jpg
-- jpeg
-- png
-- gif
-- webp
-- ttf
-- woff
-- woff2
-- eot
-- otf
-- pdf
-- wav
-- mp3
-- mpeg
-- mp4
-- zip
-- 7z
+- *Images:* jpg, jpeg, png, gif, webp
+- *Web Fonts:* ttf, woff, woff2, eot, otf
+- *Documents:* pdf
+- *Audio:* wav, mp3
+- *Video:* mpeg, mp4
+- *Archives:* zip, 7z
 
 
 This is the same list of binary file encodings supported by the Worker. If you wish to add more binary content types, add them to the array `$BinaryExtensions` in [kv-bulk-uplad.ps1](kv-bulk-upload.ps1). Make sure to associate the approriate `Content-Type` header in [libs.rs](src/libs.rs) so that the Worker can serve the new file type (and submit a pull request upstream to add them for everyone!).
@@ -78,3 +75,13 @@ The default filename for bulk uploads is the file `kv-bulk.json`, which is inclu
 #### Skipping Binary Files
 
 If you wish to skip uploading binary files (e.g. because they take too long), use the `-skipbinary` flag.
+
+### Large Files
+
+By default, the script skips files with a size larger than 100MB (to speed up CI/CD pipeline runs using GitHub Actions) and outputs a warning about a large file size. You can set a custom limit using the `-limitsize` flag:
+
+```powershell
+# uploads all files smaller than 1GB
+./kv-bulk-upload.ps1 -LimitSize 1000
+```
+Setting a limit of 0 disables the limit.

--- a/kv-bulk-upload.ps1
+++ b/kv-bulk-upload.ps1
@@ -4,7 +4,7 @@ param (
 	[String]$OutFile = "kv-bulk.json",
 	[String]$Base = ".\static\",
 	[switch]$SkipBinary,
-	[int]$LimitSize = 1
+	[int]$LimitSize = 100
 )
 $BaseDir = (Get-Item -Path $Base)
 
@@ -29,7 +29,7 @@ foreach ($File in Get-ChildItem -File -Recurse -Path $BaseDir) {
 	# This will fail if the file is empty
 	if ($File.length) {
 		if (($LimitSize -ne 0) -and (($File.length / 1MB) -gt $LimitSize)) {
-			Write-Warning "Skipping large file."
+			Write-Warning "Skipping large file: size $($File.length / 1MB)MB greater than limit $($LimitSize)MB."
 			continue
 		}
 		if ($IsBinary) {
@@ -38,7 +38,7 @@ foreach ($File in Get-ChildItem -File -Recurse -Path $BaseDir) {
 			} else {
 				Write-Host "Binary data file. Uploading in bulk."
 				Add-Content -Path $OutFile -Value "`t{`n`t`t`"key`": `"$SubPath`","
-				$EncodedContents = [convert]::ToBase64String((Get-Content -Path $File.FullName -AsByteStream))
+				$EncodedContents = [convert]::ToBase64String((Get-Content -Path $File.FullName -Raw -AsByteStream))
 				Add-Content -Path $OutFile -Value "`t`t`"value`": `"$EncodedContents`",`n`t`t`"base64`": true`n`t},"
 			}
 		} else {


### PR DESCRIPTION
# Description
Speeds up CI pipeline by reading binary files as raw byte stream. Consequently, increases default limit on large files to 100MB, since it's *way* faster now.

Also adds documentation for bulk upload script that was missing from #45.

## Type of change
- [X] Bug fix
- [ ] Improvement
- [ ] New Feature

#### Documentation
- [X] Documentation update or changelog
- [ ] Code adheres to comment guidelines

#### Testing
- [ ] Passes tests
- [ ] Adds new unit tests
